### PR TITLE
SECURITY-1011: doTestConnection/doFillCredentialsIdItems

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
@@ -167,8 +167,7 @@ public class ArgusNotifier extends Notifier {
          * @return
          */
         private boolean isUserAdmin() {
-            User currentUser = User.current();
-            return currentUser != null && currentUser.hasPermission(Jenkins.ADMINISTER);
+            return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER);
         }
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
@@ -277,7 +277,7 @@ public class ArgusNotifier extends Notifier {
                 logger.warning(
                         String.format("%s (unprivileged) tried to get the list of possible Argus credentials",
                                 User.current()));
-                return new StandardListBoxModel().includeEmptyValue();
+                return new ListBoxModel();
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifier.java
@@ -190,9 +190,6 @@ public class ArgusNotifier extends Notifier {
                                     argusUrl));
                 }
             } else {
-                logger.warning(
-                        String.format("%s (unprivileged) tried to test an Argus connection with the following URL: %s",
-                                User.current(), argusUrl));
                 return FormValidation.error("Access denied: You have not logged in or do not have administer permissions");
             }
         }
@@ -273,9 +270,6 @@ public class ArgusNotifier extends Notifier {
                                         Collections.emptyList())
                         );
             } else {
-                logger.warning(
-                        String.format("%s (unprivileged) tried to get the list of possible Argus credentials",
-                                User.current()));
                 return new ListBoxModel();
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifierTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/ArgusNotifierTest.groovy
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.argusnotifier
+
+import hudson.model.Item
+import hudson.model.User
+import hudson.security.ACL
+import jenkins.model.Jenkins
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.MockAuthorizationStrategy
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class ArgusNotifierTest extends Specification {
+    public static final ADMIN_USER = "admin"
+    public static final DEV_USER = "dev"
+    @Rule public JenkinsRule jenkinsRule = new JenkinsRule()
+
+    def "check that #user isUserAdmin() resolves to #expectedResult"() {
+        given:
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm())
+        jenkinsRule.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
+                grant(Jenkins.ADMINISTER).everywhere().to(ADMIN_USER).
+                grant(Jenkins.READ, Item.READ).everywhere().to(DEV_USER))
+        ACL.as(User.get(user).impersonate())
+
+        when:
+        boolean result = jenkinsRule.jenkins.getDescriptorByType(ArgusNotifier.DescriptorImpl).isUserAdmin()
+
+        then:
+        result == expectedResult
+
+        where:
+        user       | expectedResult
+        ADMIN_USER | true
+        DEV_USER   | false
+    }
+}


### PR DESCRIPTION
Require that a logged in user with administer privileges is the only
type of user with access to these methods as the intent is to configure
these in Manage Jenkins -> Configure System

* doTestConnection allows CSRF
* both methods allow leaking credentials