### PR TITLE
Add 2 metric tags for metric total.build.time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plugin</artifactId>
-      <version>3.43</version> <!-- or whatever the newest version available is -->
+      <version>3.43</version>
       <relativePath />
     </parent>
 
     <artifactId>argus-notifier</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>
@@ -20,6 +20,7 @@
         <java.version>1.8</java.version>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
+        <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <java.version>1.8</java.version>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <!--jenkins-test-harness.version>2.13</jenkins-test-harness.version -->
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.164.2</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>8</java.level>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>2.11</version>
-        <relativePath />
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plugin</artifactId>
+      <version>3.43</version> <!-- or whatever the newest version available is -->
+      <relativePath />
     </parent>
 
     <artifactId>argus-notifier</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.60</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>8</java.level>
         <java.version>1.8</java.version>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+        <!--jenkins-test-harness.version>2.13</jenkins-test-harness.version -->
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
@@ -38,7 +37,7 @@
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <metrics.version>3.1.2.9</metrics.version>
         <structs.version>1.10</structs.version>
-        <jackson2-api.version>2.5.4</jackson2-api.version>
+        <jackson2-api.version>2.9.8</jackson2-api.version>
     </properties>
 
     <name>Argus Notifier Plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusDataSender.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusDataSender.java
@@ -88,7 +88,7 @@ class ArgusDataSender {
             }
         } catch (Exception e) {
             if (logger.isLoggable(Level.SEVERE)) {
-                logger.log(Level.SEVERE, "Argus Notifier: Error when testing connection", e);
+                logger.log(Level.SEVERE, String.format("Argus Notifier: Error when testing connection '%s' p='%s'",credentials.getUsername(),credentials.getPassword().getPlainText()), e);
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusDataSender.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/ArgusDataSender.java
@@ -88,7 +88,7 @@ class ArgusDataSender {
             }
         } catch (Exception e) {
             if (logger.isLoggable(Level.SEVERE)) {
-                logger.log(Level.SEVERE, String.format("Argus Notifier: Error when testing connection '%s' p='%s'",credentials.getUsername(),credentials.getPassword().getPlainText()), e);
+                logger.log(Level.SEVERE, "Argus Notifier: Error when testing connection", e);
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
@@ -95,8 +95,14 @@ class BuildMetricFactory {
         // TODO: metric.setNamespace(projectName);
         double timeInSeconds = (double) timeInMillis / 1000.0;
 
-        metric.setTags(TagFactory.buildStatusTags(jenkins,
+        if (labelForDisplayName == TOTAL_BUILD_TIME_LABEL) {
+        	metric.setTags(TagFactory.buildExtendedStatusTags(jenkins,
+                    jenkinsRunFormatter.getProjectName(), jenkinsRunFormatter.getBuildNumberString(),jenkinsRunFormatter.getGitCommit()));
+        }
+        else {
+        	metric.setTags(TagFactory.buildStatusTags(jenkins,
                 jenkinsRunFormatter.getProjectName()));
+        }
         Map<Long, Double> datapoints =
                 ImmutableMap.<Long, Double>builder()
                         .put(metricTimestamp, timeInSeconds)

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
@@ -90,9 +90,10 @@ class BuildMetricFactory {
         double timeInSeconds = (double) timeInMillis / 1000.0;
 
         String gitCommitId = jenkinsRunFormatter.getGitCommit();
-        if (labelForDisplayName == TOTAL_BUILD_TIME_LABEL && !gitCommitId.isEmpty()) {
+        if (labelForDisplayName.equals(TOTAL_BUILD_TIME_LABEL) && !gitCommitId.isEmpty()) {
+            String buildStatus = BuildResultsResolver.getResultString(run.getResult());
             metric.setTags(TagFactory.buildExtendedStatusTags(jenkins, jenkinsRunFormatter.getProjectName(),
-                    jenkinsRunFormatter.getBuildNumberString(), gitCommitId));
+                    jenkinsRunFormatter.getBuildNumberString(), gitCommitId, buildStatus));
         } else {
             metric.setTags(TagFactory.buildStatusTags(jenkins, jenkinsRunFormatter.getProjectName()));
         }

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
@@ -95,9 +95,10 @@ class BuildMetricFactory {
         // TODO: metric.setNamespace(projectName);
         double timeInSeconds = (double) timeInMillis / 1000.0;
 
-        if (labelForDisplayName == TOTAL_BUILD_TIME_LABEL) {
+        String gitCommitId = jenkinsRunFormatter.getGitCommit();
+        if (labelForDisplayName == TOTAL_BUILD_TIME_LABEL && !gitCommitId.isEmpty()) {
         	metric.setTags(TagFactory.buildExtendedStatusTags(jenkins,
-                    jenkinsRunFormatter.getProjectName(), jenkinsRunFormatter.getBuildNumberString(),jenkinsRunFormatter.getGitCommit()));
+                    jenkinsRunFormatter.getProjectName(), jenkinsRunFormatter.getBuildNumberString(),gitCommitId));
         }
         else {
         	metric.setTags(TagFactory.buildStatusTags(jenkins,

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
@@ -90,13 +90,9 @@ class BuildMetricFactory {
         double timeInSeconds = (double) timeInMillis / 1000.0;
 
         String gitCommitId = jenkinsRunFormatter.getGitCommit();
-        if (labelForDisplayName.equals(TOTAL_BUILD_TIME_LABEL) && !gitCommitId.isEmpty()) {
-            String buildStatus = BuildResultsResolver.getResultString(run.getResult());
-            metric.setTags(TagFactory.buildExtendedStatusTags(jenkins, jenkinsRunFormatter.getProjectName(),
-                    jenkinsRunFormatter.getBuildNumberString(), gitCommitId, buildStatus));
-        } else {
-            metric.setTags(TagFactory.buildStatusTags(jenkins, jenkinsRunFormatter.getProjectName()));
-        }
+        String buildStatus = BuildResultsResolver.getResultString(run.getResult());
+        metric.setTags(TagFactory.buildExtendedStatusTags(jenkins, jenkinsRunFormatter.getProjectName(),
+                jenkinsRunFormatter.getBuildNumberString(), gitCommitId, buildStatus));
         Map<Long, Double> datapoints = ImmutableMap.<Long, Double>builder().put(metricTimestamp, timeInSeconds).build();
         metric.setDatapoints(datapoints);
         return metric;

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactory.java
@@ -43,23 +43,18 @@ class BuildMetricFactory {
         statusTranslatedToNumberMetric.setMetric(BUILD_STATUS);
         // TODO: statusTranslatedToNumberMetric.setNamespace(projectName);
 
-        statusTranslatedToNumberMetric.setTags(TagFactory.buildStatusTags(jenkins,
-                jenkinsRunFormatter.getProjectName()));
-        Map<Long, Double> numericStatusDatapoints =
-                ImmutableMap.<Long, Double>builder()
-                        .put(metricTimestamp, BuildResultsResolver.translateResultToNumber(run.getResult()))
-                        .build();
+        statusTranslatedToNumberMetric
+                .setTags(TagFactory.buildStatusTags(jenkins, jenkinsRunFormatter.getProjectName()));
+        Map<Long, Double> numericStatusDatapoints = ImmutableMap.<Long, Double>builder()
+                .put(metricTimestamp, BuildResultsResolver.translateResultToNumber(run.getResult())).build();
         statusTranslatedToNumberMetric.setDatapoints(numericStatusDatapoints);
         Metric buildStatusMetric = new Metric();
         buildStatusMetric.setScope(scope);
         buildStatusMetric.setDisplayName(getDisplayName(BuildResultsResolver.getResultString(run.getResult())));
         buildStatusMetric.setMetric(BuildResultsResolver.getMetricName(run.getResult()));
-        buildStatusMetric.setTags(TagFactory.buildStatusTags(jenkins,
-                jenkinsRunFormatter.getProjectName()));
-        Map<Long, Double> buildStatusDatapoints =
-                ImmutableMap.<Long, Double>builder()
-                        .put(metricTimestamp, 1.0)
-                        .build();
+        buildStatusMetric.setTags(TagFactory.buildStatusTags(jenkins, jenkinsRunFormatter.getProjectName()));
+        Map<Long, Double> buildStatusDatapoints = ImmutableMap.<Long, Double>builder().put(metricTimestamp, 1.0)
+                .build();
         buildStatusMetric.setDatapoints(buildStatusDatapoints);
         return ImmutableList.of(statusTranslatedToNumberMetric, buildStatusMetric);
     }
@@ -76,8 +71,7 @@ class BuildMetricFactory {
             buildingDurationMillis = Math.max(0L, System.currentTimeMillis() - run.getStartTimeInMillis());
             totalDurationMillis = timeInQueueAction.getQueuingDurationMillis() + buildingDurationMillis;
         }
-        return ImmutableList.of(
-                getBuildTimeMetric(BUILD_TIME_LABEL, BUILD_TIME_METRIC, buildingDurationMillis),
+        return ImmutableList.of(getBuildTimeMetric(BUILD_TIME_LABEL, BUILD_TIME_METRIC, buildingDurationMillis),
                 getBuildTimeMetric(QUEUE_TIME_LABEL, QUEUE_TIME_METRIC, timeInQueueAction.getQueuingDurationMillis()),
                 getBuildTimeMetric(TOTAL_BUILD_TIME_LABEL, TOTAL_BUILD_TIME_METRIC, totalDurationMillis));
     }
@@ -97,17 +91,12 @@ class BuildMetricFactory {
 
         String gitCommitId = jenkinsRunFormatter.getGitCommit();
         if (labelForDisplayName == TOTAL_BUILD_TIME_LABEL && !gitCommitId.isEmpty()) {
-        	metric.setTags(TagFactory.buildExtendedStatusTags(jenkins,
-                    jenkinsRunFormatter.getProjectName(), jenkinsRunFormatter.getBuildNumberString(),gitCommitId));
+            metric.setTags(TagFactory.buildExtendedStatusTags(jenkins, jenkinsRunFormatter.getProjectName(),
+                    jenkinsRunFormatter.getBuildNumberString(), gitCommitId));
+        } else {
+            metric.setTags(TagFactory.buildStatusTags(jenkins, jenkinsRunFormatter.getProjectName()));
         }
-        else {
-        	metric.setTags(TagFactory.buildStatusTags(jenkins,
-                jenkinsRunFormatter.getProjectName()));
-        }
-        Map<Long, Double> datapoints =
-                ImmutableMap.<Long, Double>builder()
-                        .put(metricTimestamp, timeInSeconds)
-                        .build();
+        Map<Long, Double> datapoints = ImmutableMap.<Long, Double>builder().put(metricTimestamp, timeInSeconds).build();
         metric.setDatapoints(datapoints);
         return metric;
     }

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildResultsResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/BuildResultsResolver.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.argusnotifier;
 
 import com.google.common.collect.ImmutableMap;
-import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.Run;
 

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
@@ -6,13 +6,12 @@ import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
 
-
 /**
  * Formatter to consistently format Jenkins and Jenkins build info
  */
 class JenkinsRunFormatter {
-    
-	public static final String GIT_COMMIT = "GIT_COMMIT";
+
+    public static final String GIT_COMMIT = "GIT_COMMIT";
     private final String jenkinsUrl;
     private final Run run;
 
@@ -34,12 +33,12 @@ class JenkinsRunFormatter {
     }
 
     /**
-     * Will return either just the build URL "job/test/42/" if the Jenkins URL is null or
-     * a full build URL.
+     * Will return either just the build URL "job/test/42/" if the Jenkins URL is
+     * null or a full build URL.
      *
      * @return full run URL if possible
      */
-     String getRunUrl() {
+    String getRunUrl() {
         if (jenkinsUrl == null) {
             return run.getUrl();
         }
@@ -59,16 +58,15 @@ class JenkinsRunFormatter {
     }
 
     public String getGitCommit() {
-    	
-    	Object commitId = run.getEnvVars().get(GIT_COMMIT);
-    	if (commitId == null) {
-    		return "";
-    	}
-    	else {
-    		return (String)commitId;
-    	}
+
+        Object commitId = run.getEnvVars().get(GIT_COMMIT);
+        if (commitId == null) {
+            return "";
+        } else {
+            return (String) commitId;
+        }
     }
-    
+
     /**
      * Convenience method to get contextual build result
      *

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
@@ -6,11 +6,13 @@ import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
 
+
 /**
  * Formatter to consistently format Jenkins and Jenkins build info
  */
 class JenkinsRunFormatter {
     
+	public static final String GIT_COMMIT = "BUILD_URL";
     private final String jenkinsUrl;
     private final Run run;
 
@@ -56,6 +58,16 @@ class JenkinsRunFormatter {
         return String.valueOf(run.getNumber());
     }
 
+    public String getGitCommit() {
+    	Object commitId = run.getEnvVars().get(GIT_COMMIT);
+    	if (commitId == null) {
+    		return "";
+    	}
+    	else {
+    		return (String)commitId;
+    	}
+    }
+    
     /**
      * Convenience method to get contextual build result
      *

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
@@ -59,6 +59,7 @@ class JenkinsRunFormatter {
     }
 
     public String getGitCommit() {
+    	
     	Object commitId = run.getEnvVars().get(GIT_COMMIT);
     	if (commitId == null) {
     		return "";

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
  */
 class JenkinsRunFormatter {
     
-	public static final String GIT_COMMIT = "BUILD_URL";
+	public static final String GIT_COMMIT = "GIT_COMMIT";
     private final String jenkinsUrl;
     private final Run run;
 

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatter.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.argusnotifier;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins;
@@ -66,7 +65,7 @@ class JenkinsRunFormatter {
      * Get GIT_COMMIT environment variable if available.
      * 
      * 
-     * @return commit sha as String, return empty String if not available.
+     * @return GIT commit sha as String, return empty String if not available.
      */
     public String getGitCommit() {
         

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
@@ -41,11 +41,11 @@ class TagFactory {
     /**
      * Create immutable map of tags for a build time metric
      * 
-     * @param jenkins
-     * @param projectName
-     * @param buildNumber
-     * @param commitId
-     * @param status
+     * @param jenkins Jenkins instance
+     * @param projectName build project name
+     * @param buildNumber build number or id
+     * @param commitId github commit sha associated with this build, set to empty if not applicable
+     * @param status the build status, SUCCESS, FAILURE or UNSTABLE etc
      * @return
      */
     static Map<String, String> buildExtendedStatusTags(Jenkins jenkins, String projectName, String buildNumber,

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
@@ -32,13 +32,16 @@ class TagFactory {
      * @return
      */
     static Map<String, String> buildStatusTags(Jenkins jenkins, String projectName) {
-        return ImmutableMap.<String, String>builder().putAll(hostTag(jenkins))
-                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName)).build();
-    }
-
+        return ImmutableMap.<String, String>builder()
+                .putAll(hostTag(jenkins))
+                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName))
+                .build();
+    }    
+    
     /**
-     * Create immutable map of tags for build status tags
-     * @param jenkins Jenkins instance
+     * Create immutable map of tags for a build time metric
+     * 
+     * @param jenkins
      * @param projectName
      * @param buildNumber
      * @param commitId
@@ -50,7 +53,12 @@ class TagFactory {
 
         ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
                 .putAll(hostTag(jenkins)).put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName));
-        mapBuilder.put(BUILD_NUMBER.lower(), buildNumber).put(GIT_COMMIT.lower(), commitId).put(BUILD_STATUS.lower(),status);
+        mapBuilder.put(BUILD_NUMBER.lower(), buildNumber).put(BUILD_STATUS.lower(),status);
+        
+        if (!commitId.isEmpty()) {
+            mapBuilder.put(GIT_COMMIT.lower(), commitId);
+        }
+            
         return mapBuilder.build();
 
     }

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
@@ -13,7 +13,7 @@ import static org.jenkinsci.plugins.argusnotifier.TagFactory.Tag.*;
  */
 class TagFactory {
     enum Tag {
-        HOST, BUILD_NUMBER, GIT_COMMIT, PROJECT;
+        HOST, BUILD_NUMBER, GIT_COMMIT, BUILD_STATUS, PROJECT;
 
         public String lower() {
             return name().toLowerCase();
@@ -36,12 +36,21 @@ class TagFactory {
                 .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName)).build();
     }
 
+    /**
+     * Create immutable map of tags for build status tags
+     * @param jenkins Jenkins instance
+     * @param projectName
+     * @param buildNumber
+     * @param commitId
+     * @param status
+     * @return
+     */
     static Map<String, String> buildExtendedStatusTags(Jenkins jenkins, String projectName, String buildNumber,
-            String commitId) {
+            String commitId, String status) {
 
         ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
                 .putAll(hostTag(jenkins)).put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName));
-        mapBuilder.put(BUILD_NUMBER.lower(), buildNumber).put(GIT_COMMIT.lower(), commitId);
+        mapBuilder.put(BUILD_NUMBER.lower(), buildNumber).put(GIT_COMMIT.lower(), commitId).put(BUILD_STATUS.lower(),status);
         return mapBuilder.build();
 
     }

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.argusnotifier;
 
 import com.google.common.collect.ImmutableMap;
 import jenkins.model.Jenkins;
-
 import java.util.Map;
 
 import static org.jenkinsci.plugins.argusnotifier.TagFactory.Tag.*;
@@ -15,6 +14,8 @@ import static org.jenkinsci.plugins.argusnotifier.TagFactory.Tag.*;
 class TagFactory {
     enum Tag {
         HOST,
+        BUILD_NUMBER,
+        GIT_COMMIT,
         PROJECT;
 
         public String lower() {
@@ -38,6 +39,20 @@ class TagFactory {
                 .putAll(hostTag(jenkins))
                 .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName))
                 .build();
+    }
+    
+    static Map<String, String> buildExtendedStatusTags(Jenkins jenkins, String projectName, String buildNumber,String commitId) {
+    	
+    	ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
+                .putAll(hostTag(jenkins))
+                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName));
+                
+        if (!commitId.isEmpty()) {
+        	mapBuilder.put(BUILD_NUMBER.lower(),buildNumber)
+                .put(GIT_COMMIT.lower(),commitId);
+        }
+        return mapBuilder.build();
+
     }
 
     static Map<String, String> hostTag(Jenkins jenkins) {

--- a/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/argusnotifier/TagFactory.java
@@ -13,10 +13,7 @@ import static org.jenkinsci.plugins.argusnotifier.TagFactory.Tag.*;
  */
 class TagFactory {
     enum Tag {
-        HOST,
-        BUILD_NUMBER,
-        GIT_COMMIT,
-        PROJECT;
+        HOST, BUILD_NUMBER, GIT_COMMIT, PROJECT;
 
         public String lower() {
             return name().toLowerCase();
@@ -35,29 +32,21 @@ class TagFactory {
      * @return
      */
     static Map<String, String> buildStatusTags(Jenkins jenkins, String projectName) {
-        return ImmutableMap.<String, String>builder()
-                .putAll(hostTag(jenkins))
-                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName))
-                .build();
+        return ImmutableMap.<String, String>builder().putAll(hostTag(jenkins))
+                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName)).build();
     }
-    
-    static Map<String, String> buildExtendedStatusTags(Jenkins jenkins, String projectName, String buildNumber,String commitId) {
-    	
-    	ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
-                .putAll(hostTag(jenkins))
-                .put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName));
-                
-        if (!commitId.isEmpty()) {
-        	mapBuilder.put(BUILD_NUMBER.lower(),buildNumber)
-                .put(GIT_COMMIT.lower(),commitId);
-        }
+
+    static Map<String, String> buildExtendedStatusTags(Jenkins jenkins, String projectName, String buildNumber,
+            String commitId) {
+
+        ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
+                .putAll(hostTag(jenkins)).put(PROJECT.lower(), InvalidCharSwap.swapWithDash(projectName));
+        mapBuilder.put(BUILD_NUMBER.lower(), buildNumber).put(GIT_COMMIT.lower(), commitId);
         return mapBuilder.build();
 
     }
 
     static Map<String, String> hostTag(Jenkins jenkins) {
-        return ImmutableMap.<String, String>builder()
-                .put(HOST.lower(), JenkinsFormatter.getHostName(jenkins))
-                .build();
+        return ImmutableMap.<String, String>builder().put(HOST.lower(), JenkinsFormatter.getHostName(jenkins)).build();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactoryTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactoryTest.groovy
@@ -5,7 +5,6 @@ import hudson.model.ItemGroup
 import hudson.model.Job
 import hudson.model.Run
 import hudson.model.Result
-import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -17,7 +16,6 @@ class BuildMetricFactoryTest extends Specification {
     private Jenkins jenkins = Mock(Jenkins)
     private Run run = Mock(Run)
     private ItemGroup folder = Mock(ItemGroup)
-    private LogTaskListener listener = Mock(LogTaskListener)
 
     def setup() {
         jenkins.rootUrl >> "jenkinsrooturl"

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactoryTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/BuildMetricFactoryTest.groovy
@@ -68,9 +68,9 @@ class BuildMetricFactoryTest extends Specification {
         then:
 
         metricTotalTime.tags[commitTag.toLowerCase()].equals(expectedCommit)
-        metricTotalTime.tags[TagFactory.Tag.BUILD_NUMBER.lower()].equals(commitId.isEmpty() ? null : String.valueOf(buildNumber))
+        metricTotalTime.tags[TagFactory.Tag.BUILD_NUMBER.lower()].equals(String.valueOf(buildNumber))
         metricTotalTime.tags[TagFactory.Tag.PROJECT.lower()].startsWith(jobFolderName)
-        metricTotalTime.tags[TagFactory.Tag.BUILD_STATUS.lower()].equals(commitId.isEmpty() ? null : Result.SUCCESS.toString())
+        metricTotalTime.tags[TagFactory.Tag.BUILD_STATUS.lower()].equals(Result.SUCCESS.toString())
 
 
         where:

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
@@ -70,44 +70,43 @@ class JenkinsRunFormatterTest extends Specification {
         then:
         actualBuildNumberString == String.valueOf(buildNumber)
     }
-	
-	def "test getGitCommit returns commit sha"() {
-		given:
-		def gitCommit = commitId
-		
-		ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
-		mapBuilder.put(JenkinsRunFormatter.GIT_COMMIT, gitCommit)
-		build.getEnvVars() >> mapBuilder.build()
-		JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
-		
-		when:
-		String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
-		
-		then:
-		actualGitCommit == expectedGitCommit
-		
-		where:
-		commitId               | expectedGitCommit
-		"sdsfafdfssdf"     	   | "sdsfafdfssdf"
-		"f6fd56be96ccb7f445c6d8058b76b4c2482a50a6" | "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6"
-	}
-	
-	def "test getGitCommit no such env variable"() {
-		given:
-		def gitCommit = "343245dsawer32fd43fd43"
-		
-		ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
-		mapBuilder.put("ENV_VAR", gitCommit)
-		build.getEnvVars() >> mapBuilder.build()
-		JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
-		
-		when:
-		String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
-		
-		then:
-		actualGitCommit == ""
 
-	}
+    def "test getGitCommit returns commit sha"() {
+        given:
+        def gitCommit = commitId
+
+        ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
+        mapBuilder.put(JenkinsRunFormatter.GIT_COMMIT, gitCommit)
+        build.getEnvVars() >> mapBuilder.build()
+        JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
+
+        when:
+        String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
+
+        then:
+        actualGitCommit == expectedGitCommit
+
+        where:
+        commitId               | expectedGitCommit
+        "sdsfafdfssdf"         | "sdsfafdfssdf"
+        "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6" | "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6"
+    }
+
+    def "test getGitCommit no such env variable"() {
+        given:
+        def gitCommit = "343245dsawer32fd43fd43"
+
+        ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
+        mapBuilder.put("ENV_VAR", gitCommit)
+        build.getEnvVars() >> mapBuilder.build()
+        JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
+
+        when:
+        String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
+
+        then:
+        actualGitCommit == ""
+    }
 
     def "test getContextualResult properly returns FIXED"() {
         // No need to test all of the corner cases again

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
@@ -7,6 +7,7 @@ import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.MockFolder
 import spock.lang.Specification
 import spock.lang.Unroll
+import com.google.common.collect.ImmutableMap
 
 @Unroll
 class JenkinsRunFormatterTest extends Specification {
@@ -69,6 +70,44 @@ class JenkinsRunFormatterTest extends Specification {
         then:
         actualBuildNumberString == String.valueOf(buildNumber)
     }
+	
+	def "test getGitCommit returns commit sha"() {
+		given:
+		def gitCommit = commitId
+		
+		ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
+		mapBuilder.put(JenkinsRunFormatter.GIT_COMMIT, gitCommit)
+		build.getEnvVars() >> mapBuilder.build()
+		JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
+		
+		when:
+		String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
+		
+		then:
+		actualGitCommit == expectedGitCommit
+		
+		where:
+		commitId               | expectedGitCommit
+		"sdsfafdfssdf"     	   | "sdsfafdfssdf"
+		"f6fd56be96ccb7f445c6d8058b76b4c2482a50a6" | "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6"
+	}
+	
+	def "test getGitCommit no such env variable"() {
+		given:
+		def gitCommit = "343245dsawer32fd43fd43"
+		
+		ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
+		mapBuilder.put("ENV_VAR", gitCommit)
+		build.getEnvVars() >> mapBuilder.build()
+		JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
+		
+		when:
+		String actualGitCommit = jenkinsBuildFormatter.getGitCommit()
+		
+		then:
+		actualGitCommit == ""
+
+	}
 
     def "test getContextualResult properly returns FIXED"() {
         // No need to test all of the corner cases again

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
@@ -1,13 +1,13 @@
 package org.jenkinsci.plugins.argusnotifier
 
 import hudson.model.*
+import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.MockFolder
 import spock.lang.Specification
 import spock.lang.Unroll
-import com.google.common.collect.ImmutableMap
 
 @Unroll
 class JenkinsRunFormatterTest extends Specification {
@@ -18,6 +18,7 @@ class JenkinsRunFormatterTest extends Specification {
     private static final String TEST_BUILD_URL = "job/test/42/"
     private AbstractBuild build = Mock(AbstractBuild)
     private Jenkins jenkins = Mock(Jenkins)
+    private LogTaskListener listener = Mock(LogTaskListener)
 
     def setup() {
         build.getResult() >> Result.SUCCESS
@@ -71,13 +72,9 @@ class JenkinsRunFormatterTest extends Specification {
         actualBuildNumberString == String.valueOf(buildNumber)
     }
 
-    def "test getGitCommit returns commit sha"() {
+    def "test getGitCommit for #commitId returns commit sha #expectedGitCommit"() {
         given:
-        def gitCommit = commitId
-
-        ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
-        mapBuilder.put(JenkinsRunFormatter.GIT_COMMIT, gitCommit)
-        build.getEnvVars() >> mapBuilder.build()
+        build.getEnvironment(_) >> [(TagFactory.Tag.GIT_COMMIT.toString()): commitId]
         JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
 
         when:
@@ -94,11 +91,7 @@ class JenkinsRunFormatterTest extends Specification {
 
     def "test getGitCommit no such env variable"() {
         given:
-        def gitCommit = "343245dsawer32fd43fd43"
-
-        ImmutableMap.Builder<String,String> mapBuilder = ImmutableMap.<String, String>builder()
-        mapBuilder.put("ENV_VAR", gitCommit)
-        build.getEnvVars() >> mapBuilder.build()
+        build.getEnvironment(_) >> [:]
         JenkinsRunFormatter jenkinsBuildFormatter = new JenkinsRunFormatter(jenkins, build)
 
         when:

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
@@ -87,8 +87,8 @@ class JenkinsRunFormatterTest extends Specification {
         actualGitCommit == expectedGitCommit
 
         where:
-        commitId               | expectedGitCommit
-        "sdsfafdfssdf"         | "sdsfafdfssdf"
+        commitId                                   | expectedGitCommit
+        "0fc255bb26fcc4a0548c3ca14caec6a7d6de7c25" | "0fc255bb26fcc4a0548c3ca14caec6a7d6de7c25"
         "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6" | "f6fd56be96ccb7f445c6d8058b76b4c2482a50a6"
     }
 

--- a/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
+++ b/src/test/java/org/jenkinsci/plugins/argusnotifier/JenkinsRunFormatterTest.groovy
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.argusnotifier
 
 import hudson.model.*
-import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
@@ -18,7 +17,6 @@ class JenkinsRunFormatterTest extends Specification {
     private static final String TEST_BUILD_URL = "job/test/42/"
     private AbstractBuild build = Mock(AbstractBuild)
     private Jenkins jenkins = Mock(Jenkins)
-    private LogTaskListener listener = Mock(LogTaskListener)
 
     def setup() {
         build.getResult() >> Result.SUCCESS


### PR DESCRIPTION
Hi Vijay,
Thanks for your time reviewing this code change. This is a small change: Justin agreed to let me add 2 tags for the metric named "total.build.time":
git_commit
build_number
And this is the code change and unit test for it.

With these 2 additional tags I can get all the necessary info to develop our CI Service visibility report for CRM Infra.

Thanks a lot!