### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 #!/usr/bin/env groovy
-buildPlugin(platforms: ['linux'], jdkVersions: [8], findbugs: [archive: true, unstableTotalAll: '0'])
+buildPlugin(platforms: ['linux'], jdkVersions: [8])


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.